### PR TITLE
feat: support darwin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,8 +5,11 @@ on:
 
 jobs:
   flake-check:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     name: Flake check (locked)
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3.0.2
     - uses: cachix/install-nix-action@v17

--- a/build-rust-crate/default.nix
+++ b/build-rust-crate/default.nix
@@ -1,4 +1,4 @@
-{ lib, nocargo-lib, stdenv, buildPackages, rust, toml2json, jq }:
+{ lib, nocargo-lib, stdenv, buildPackages, rust, toml2json, jq, darwin }:
 { pname
 , version
 , src
@@ -13,6 +13,7 @@
 , profile ? {}
 , capLints ? null
 
+, buildInputs ? []
 , nativeBuildInputs ? []
 , propagatedBuildInputs ? []
 , ...
@@ -65,6 +66,13 @@ let
     inherit pname version src;
 
     nativeBuildInputs = [ toml2json jq ] ++ nativeBuildInputs;
+
+    buildInputs = lib.optionals stdenv.isDarwin [
+      darwin.Security
+      darwin.apple_sdk.frameworks.CoreServices
+      darwin.cf-private
+      darwin.libiconv
+    ] ++ buildInputs;
 
     sharedLibraryExt = stdenv.hostPlatform.extensions.sharedLibrary;
 

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
 
   outputs = { self, flake-utils, nixpkgs, registry-crates-io }@inputs:
     let
-      supportedSystems = [ "x86_64-linux" ];
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
 
       inherit (builtins) readFile fromJSON toJSON typeOf;
       inherit (nixpkgs.lib)

--- a/toml2json/default.nix
+++ b/toml2json/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, rustc }:
+{ lib, stdenv, fetchurl, rustc, darwin }:
 let
   fetch = name: version: sha256:
     fetchurl {
@@ -18,6 +18,7 @@ in stdenv.mkDerivation {
 
   sourceRoot = ".";
 
+  buildInputs = lib.optional stdenv.isDarwin darwin.libiconv;
   nativeBuildInputs = [ rustc ];
 
   buildPhase = ''


### PR DESCRIPTION
I tried to test this on my MBP with m1 chip. `nix build .` works.

I tried to `build .#cache` but failed.

```
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
unpacking source archive /nix/store/y941nzsc6gnvxm5j9b1f82914lvjfzab-crate-cpufeatures-0.2.4.tar.gz
source root is cpufeatures-0.2.4
setting SOURCE_DATE_EPOCH to timestamp 1153704088 of file cpufeatures-0.2.4/tests/x86.rs
@nix { "action": "setPhase", "phase": "patchPhase" }
patching sources
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "configurePhase" }
configuring
@nix { "action": "setPhase", "phase": "buildPhase" }
building
Building lib: RUSTC 'src/lib.rs' '--out-dir=/nix/store/0gv5l8sd6zxq5j2gajaggzlvl6gwsfml-rust_cpufeatures-0.2.4/lib' '--crate-name=cpufeatures' '--crate-type=lib' '--emit=metadata,link' '-Cembed-bitcode=no' '-Cextra-filename=-d0377ca44dd1550e' '--color=always' '-Copt-level=3' '-Cdebuginfo=0' '-Cdebug-assertions=no' '-Coverflow-checks=no' '-Clto=no' '-Cpanic=unwind' '-Ccodegen-units=16' '--cap-lints=allow' '-Cmetadata=d0377ca44dd1550e' '--edition=2018' '-Ldependency=/nix/store/fawhjckz2y94w3brj9qxpsc43ivmbxqc-rust_cpufeatures-0.2.4-dev/rust-support/deps-closure'
error[E0433]: failed to resolve: use of undeclared crate or module `libc`
   --> src/aarch64.rs:133:14
    |
133 |     let rc = libc::sysctlbyname(
    |              ^^^^ use of undeclared crate or module `libc`

error[E0433]: failed to resolve: use of undeclared crate or module `libc`
   --> src/aarch64.rs:135:38
    |
135 |         &mut value as *mut _ as *mut libc::c_void,
    |                                      ^^^^ use of undeclared crate or module `libc`

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0433`.
```

I don't think it's related to my modification but still needs some investigation.