### PR TITLE
Add aarch64-linux support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
 
   outputs = { self, flake-utils, nixpkgs, registry-crates-io }@inputs:
     let
-      supportedSystems = [ "x86_64-linux" ];
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
 
       inherit (builtins) toJSON typeOf;
       inherit (nixpkgs.lib) isDerivation isFunction isAttrs mapAttrsToList listToAttrs flatten;

--- a/noc/templates/init-flake.nix
+++ b/noc/templates/init-flake.nix
@@ -25,7 +25,7 @@
   };
 
   outputs = { nixpkgs, flake-utils, nocargo, ... }@inputs:
-    flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (system:
       let
         ws = nocargo.lib.${system}.mkRustPackageOrWorkspace {
           src = ./.;


### PR DESCRIPTION
I tested this by creating a new rust project with `cargo new --bin`, generating a `Cargo.lock` file, running `nix run /tmp/nocargo init` (where `/tmp/nocargo` is the location of my patched version of `nocargo`). Then `nix run` works great.