### PR TITLE
New feature resolver, workspace inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ Build Rust crates with *Nix Build System*.
     - [ ] Auto-`members`
     - [x] `excludes`
       FIXME: Buggy.
-  - [ ] `resolver`
-        Currently has custom resolution algorithm, more like v2.
+  - [x] `resolver`
   - [x] `links`
   - [x] `[profile]`
   - [x] `[{,dev-,build-}dependencies]`

--- a/build-rust-crate/builder-bin.sh
+++ b/build-rust-crate/builder-bin.sh
@@ -59,7 +59,12 @@ configurePhase() {
 
     convertCargoToml
 
-    globalEdition="$(jq --raw-output '.package.edition // ""' "$cargoTomlJson")"
+    if [[ -z "$edition" ]]; then
+        globalEdition="$(jq --raw-output '.package.edition // ""' "$cargoTomlJson")"
+    else
+        globalEdition="$edition"
+    fi
+    
     pkgName="$(jq --raw-output '.package.name // ""' "$cargoTomlJson")"
 
     # For packages with the 2015 edition, the default for auto-discovery is false if at least one target is
@@ -77,6 +82,7 @@ configurePhase() {
     while read -r name; do
         read -r path
         read -r binEdition
+
         addBin "$name" "$path" "$binEdition"
         # Don't strip whitespace.
     done < <(jq --raw-output '.bin // [] | .[] | .name // "", .path // "", .edition // ""' "$cargoTomlJson")

--- a/build-rust-crate/builder-build-script.sh
+++ b/build-rust-crate/builder-build-script.sh
@@ -20,7 +20,9 @@ configurePhase() {
         exit 0
     fi
 
-    edition="$(jq --raw-output '.package.edition // ""' "$cargoTomlJson")"
+    if [[ -z "$edition" ]]; then
+        edition="$(jq --raw-output '.package.edition // .lib.edition // ""' "$cargoTomlJson")"
+    fi
     if [[ -n "$edition" ]]; then
         buildFlagsArray+=(--edition="$edition")
     fi

--- a/build-rust-crate/builder-common.sh
+++ b/build-rust-crate/builder-common.sh
@@ -119,9 +119,9 @@ setCargoCommonBuildEnv() {
         CARGO_PKG_HOMEPAGE CARGO_PKG_LICENSE CARGO_PKG_LICENSE_FILE
 
     if [[ "$version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-([A-Za-z0-9.-]+))?(\+.*)?$ ]]; then
-        export CARGO_PKG_VERSION_MAJOR="${BASH_REMATCH[0]}"
-        export CARGO_PKG_VERSION_MINOR="${BASH_REMATCH[1]}"
-        export CARGO_PKG_VERSION_PATCH="${BASH_REMATCH[2]}"
+        export CARGO_PKG_VERSION_MAJOR="${BASH_REMATCH[1]}"
+        export CARGO_PKG_VERSION_MINOR="${BASH_REMATCH[2]}"
+        export CARGO_PKG_VERSION_PATCH="${BASH_REMATCH[3]}"
         export CARGO_PKG_VERSION_PRE="${BASH_REMATCH[4]}"
     else
         echo "Invalid version: $version"

--- a/build-rust-crate/builder-lib.sh
+++ b/build-rust-crate/builder-lib.sh
@@ -25,7 +25,10 @@ configurePhase() {
         exit 1
     fi
 
-    edition="$(jq --raw-output '.package.edition // .lib.edition // ""' "$cargoTomlJson")"
+    if [[ -z "$edition" ]]; then
+        edition="$(jq --raw-output '.package.edition // .lib.edition // ""' "$cargoTomlJson")"
+    fi
+    
     if [[ -n "$edition" ]]; then
         buildFlagsArray+=(--edition="$edition")
     fi

--- a/build-rust-crate/builder-lib.sh
+++ b/build-rust-crate/builder-lib.sh
@@ -52,6 +52,7 @@ configurePhase() {
                 needLinkDeps=1
                 ;;
             cdylib)
+                needLinkDeps=1
                 buildCdylib=1
                 ;;
             *)

--- a/build-rust-crate/builder-lib.sh
+++ b/build-rust-crate/builder-lib.sh
@@ -31,7 +31,8 @@ configurePhase() {
     fi
 
     mapfile -t crateTypes < <(jq --raw-output '.lib."crate-type" // ["lib"] | .[]' "$cargoTomlJson")
-    cargoTomlIsProcMacro="$(jq --raw-output 'if .lib."proc-macro" then "1" else "" end' "$cargoTomlJson")"
+    cargoTomlIsProcMacro="$(jq --raw-output 'if .lib."proc-macro" or .lib."proc_macro" then "1" else "" end' "$cargoTomlJson")"
+
     if [[ "$cargoTomlIsProcMacro" != "$procMacro" ]]; then
         echo "Cargo.toml says proc-macro = ${cargoTomlIsProcMacro:-0} but it is built with procMacro = ${procMacro:-0}"
         exit 1

--- a/build-rust-crate/default.nix
+++ b/build-rust-crate/default.nix
@@ -54,6 +54,7 @@ let
 
   # https://doc.rust-lang.org/cargo/reference/profiles.html
   profileToRustcFlags = p:
+    builtins.trace p (
     []
     ++ lib.optional (p.opt-level or 0 != 0) "-Copt-level=${toString p.opt-level}"
     ++ lib.optional (p.debug or false != false) "-Cdebuginfo=${if p.debug == true then "2" else toString p.debug}"
@@ -67,7 +68,7 @@ let
     ++ lib.optional (p.rpath or false) "-Crpath"
 
     ++ lib.optional (p.lto or false == false) "-Cembed-bitcode=no"
-    ;
+    );
 
   convertProfile = p: {
     buildFlags =

--- a/build-rust-crate/default.nix
+++ b/build-rust-crate/default.nix
@@ -54,7 +54,6 @@ let
 
   # https://doc.rust-lang.org/cargo/reference/profiles.html
   profileToRustcFlags = p:
-    builtins.trace p (
     []
     ++ lib.optional (p.opt-level or 0 != 0) "-Copt-level=${toString p.opt-level}"
     ++ lib.optional (p.debug or false != false) "-Cdebuginfo=${if p.debug == true then "2" else toString p.debug}"
@@ -68,7 +67,7 @@ let
     ++ lib.optional (p.rpath or false) "-Crpath"
 
     ++ lib.optional (p.lto or false == false) "-Cembed-bitcode=no"
-    );
+    ;
 
   convertProfile = p: {
     buildFlags =

--- a/build-rust-crate/default.nix
+++ b/build-rust-crate/default.nix
@@ -86,7 +86,7 @@ let
   };
 
   profile' = convertProfile profile;
-  buildProfile' = convertProfile (profile.build-override or {});
+  buildProfile' = convertProfile ({inherit (profile) name;} // (profile.build-override or {}));
 
   commonArgs = {
     inherit pname version src;

--- a/build-rust-crate/default.nix
+++ b/build-rust-crate/default.nix
@@ -133,8 +133,8 @@ let
 
     linksDependencies = map (dep: dep.drv.buildDrv) linksDependencies;
 
-    HOST = rust.toRustTarget stdenv.buildPlatform;
-    TARGET = rust.toRustTarget stdenv.hostPlatform;
+    HOST = stdenv.buildPlatform.rust.rustcTarget;
+    TARGET = stdenv.hostPlatform.rust.rustcTarget;
 
     # This drv links for `build_script_build`.
     # So include transitively propagated upstream `-sys` crates' ld dependencies.

--- a/flake.lock
+++ b/flake.lock
@@ -18,6 +18,21 @@
         "type": "github"
       }
     },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1687178632,
+        "narHash": "sha256-HS7YR5erss0JCaUijPeyg2XrisEb959FIct3n2TMGbE=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "d90c75e8319d0dd9be67d933d8eb9d0894ec9174",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1687274257,
@@ -53,6 +68,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs",
         "registry-crates-io": "registry-crates-io"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1687171271,
+        "narHash": "sha256-BJlq+ozK2B1sJDQXS3tzJM5a+oVZmi1q0FlBK/Xqv7M=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "abfb11bd1aec8ced1c9bb9adfe68018230f4fb3c",
         "type": "github"
       },
       "original": {
@@ -17,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1664177230,
-        "narHash": "sha256-eyo88ffm16I0K9cdcePbOsQg4MDjf1EgIdkGTLB/7iA=",
+        "lastModified": 1687274257,
+        "narHash": "sha256-TutzPriQcZ8FghDhEolnHcYU2oHIG5XWF+/SUBNnAOE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ff9793cfd1a25145a7e591af604675b3d6f68987",
+        "rev": "2c9ecd1f0400076a4d6b2193ad468ff0a7e7fdc5",
         "type": "github"
       },
       "original": {
@@ -34,11 +37,11 @@
     "registry-crates-io": {
       "flake": false,
       "locked": {
-        "lastModified": 1664219937,
-        "narHash": "sha256-ys/nswnAXBxMIbaWGKAWe5bG6PoNNqDEhFHwNaBOfPI=",
+        "lastModified": 1687368692,
+        "narHash": "sha256-vea7/HoWjB2HQOTaTB4n6ONRCdEmfeBSKUr2QI2ciTs=",
         "owner": "rust-lang",
         "repo": "crates.io-index",
-        "rev": "137ad8a5c700f01a0bbd90a9c62191c0decd0654",
+        "rev": "a27258f846f596645399e0868d6d9fe7d0a7f65f",
         "type": "github"
       },
       "original": {
@@ -52,6 +55,21 @@
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "registry-crates-io": "registry-crates-io"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,7 @@
 {
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
+    nix-filter.url = "github:numtide/nix-filter";
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     registry-crates-io = {
       url = "github:rust-lang/crates.io-index";
@@ -8,14 +9,14 @@
     };
   };
 
-  outputs = { self, flake-utils, nixpkgs, registry-crates-io }@inputs:
+  outputs = { self, flake-utils, nixpkgs, registry-crates-io, nix-filter }@inputs:
     let
       supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
 
       inherit (builtins) toJSON typeOf;
       inherit (nixpkgs.lib) isDerivation isFunction isAttrs mapAttrsToList listToAttrs flatten;
 
-      nocargo-lib = import ./lib { inherit (nixpkgs) lib; };
+      nocargo-lib = import ./lib { inherit (nixpkgs) lib; inherit nix-filter; };
 
     in flake-utils.lib.eachSystem supportedSystems (system:
       let

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,4 +1,4 @@
-{ lib }:
+{ lib, nix-filter }:
 let
   callLib = file: import file { inherit lib self; };
   self = {
@@ -9,5 +9,6 @@ let
     pkg-info = callLib ./pkg-info.nix;
     resolve = callLib ./resolve.nix;
     support = callLib ./support.nix;
+    inherit nix-filter;
   };
 in self

--- a/lib/pkg-info.nix
+++ b/lib/pkg-info.nix
@@ -111,9 +111,9 @@ rec {
     mkSrc:
     # https://github.com/rust-lang/cargo/blob/2f3df16921deb34a92700f4d5a7ecfb424739558/src/cargo/sources/registry/mod.rs#L259
     { name, vers, deps, features, cksum, yanked ? false, links ? null, v ? 1, ... }:
-    if v != 1 then
-      throw "${name} ${vers}: Registry layout version ${toString v} is too new to understand"
-    else
+    #if v != 1 then
+      #throw "${name} ${vers}: Registry layout version ${toString v} is too new to understand"
+    #else
     {
       inherit name features yanked links;
       version = vers;

--- a/lib/pkg-info.nix
+++ b/lib/pkg-info.nix
@@ -54,7 +54,8 @@ rec {
     info = crate.${version} or null;
   in
     if !(index ? __registry_index) then
-      throw "Invalid registry. Do you forget `mkIndex` on registry paths?"
+      info
+      #throw "Invalid registry. Do you forget `mkIndex` on registry paths?"
     else if crate == null then
       throw "Package ${name} is not found in index"
     else if info == null then

--- a/lib/pkg-info.nix
+++ b/lib/pkg-info.nix
@@ -216,7 +216,7 @@ rec {
       procMacro = args.lib.proc-macro or false;
       dependencies =
         collectTargetDeps null args ++
-        mapAttrsToList collectTargetDeps target;
+        (lib.lists.flatten (mapAttrsToList collectTargetDeps target));
     };
 
   pkg-info-from-toml-tests = { assertEq, ... }: {

--- a/lib/pkg-info.nix
+++ b/lib/pkg-info.nix
@@ -242,6 +242,7 @@ rec {
       expected = {
         name = "tokio-app";
         version = "0.0.0";
+        edition = "2018";
         features = { };
         src = "<src>";
         links = null;
@@ -269,6 +270,7 @@ rec {
         info = mkPkgInfoFromCargoToml cargoToml "<src>" {};
         expected = {
           name = "build-deps";
+          edition = "2015";
           version = "0.0.0";
           features = { };
           src = "<src>";

--- a/lib/pkg-info.nix
+++ b/lib/pkg-info.nix
@@ -54,8 +54,7 @@ rec {
     info = crate.${version} or null;
   in
     if !(index ? __registry_index) then
-      info
-      #throw "Invalid registry. Do you forget `mkIndex` on registry paths?"
+      throw "Invalid registry. Do you forget `mkIndex` on registry paths?"
     else if crate == null then
       throw "Package ${name} is not found in index"
     else if info == null then

--- a/lib/pkg-info.nix
+++ b/lib/pkg-info.nix
@@ -109,12 +109,10 @@ rec {
   mkPkgInfoFromRegistry =
     mkSrc:
     # https://github.com/rust-lang/cargo/blob/2f3df16921deb34a92700f4d5a7ecfb424739558/src/cargo/sources/registry/mod.rs#L259
-    { name, vers, deps, features, cksum, yanked ? false, links ? null, v ? 1, ... }:
-    #if v != 1 then
-      #throw "${name} ${vers}: Registry layout version ${toString v} is too new to understand"
-    #else
+    { name, vers, deps, features, cksum, yanked ? false, links ? null, features2 ? {}, ... }:
     {
-      inherit name features yanked links;
+      inherit name yanked links;
+      features = features // features2;
       version = vers;
       sha256 = cksum;
       dependencies = map sanitizeDep deps;

--- a/lib/resolve.nix
+++ b/lib/resolve.nix
@@ -186,9 +186,9 @@ in rec {
         let filtered = filter (dep: dep.name == dep-name) pkgSet.${pkgId}.dependencies; in
         if (length filtered) > 0 then
           lib.lists.findSingle
-            (dep: dep.targetEnabled)
+            (dep: dep.targetEnabled && dep.kind == kind)
             null # if none is found
-            (throw "Dependency ${dep-name} is ambiguous for package ${pkgId}") # if more than 1 is found
+            (throw "Dependency ${dep-name} is ambiguous for package ${pkgId}.\n${toJSON filtered}") # if more than 1 is found
             filtered
         else
           throw "Cannot find depedency ${dep-name} for ${pkgId}.";

--- a/lib/resolve.nix
+++ b/lib/resolve.nix
@@ -293,8 +293,7 @@ in rec {
           defer-feature
         else
           enableFeature {
-            inherit pkgSet feat-name;
-            inherit (dep) kind;
+            inherit pkgSet feat-name kind;
             seen = enable-dependency;
             pkgId = dep.resolved;
           }

--- a/lib/resolve.nix
+++ b/lib/resolve.nix
@@ -196,7 +196,7 @@ in rec {
     };
     key-type = {
       features = attrset;
-      attr-name = attrset;
+      deferred = attrset;
       enabled = bool;
     };
   in changes:

--- a/lib/resolve.nix
+++ b/lib/resolve.nix
@@ -500,8 +500,8 @@ in rec {
     };
 
     merge = test pkgSet2 "my-id" [ "default" ] {
-      my-id = [ "default" "tokio" ];
-      dep-id = [ "default" "tokio"];
+      my-id = [ "default" ];
+      dep-id = [ "default" ];
       tokio-id = [ "fs" "sync" "macros" ];
     };
   };

--- a/lib/support.nix
+++ b/lib/support.nix
@@ -112,7 +112,7 @@ rec {
         (map (relativePath:
           let
             memberSrc =  src + ("/" + relativePath);
-            memberRoot = self.nix-filter.lib { root = builtins.trace memberSrc memberSrc; };
+            memberRoot = if relativePath == "" then memberSrc else self.nix-filter.lib { root = builtins.trace memberSrc memberSrc; };
             memberManifest = fromTOML (readFile (memberSrc + "/Cargo.toml")) // lockVersionSet;
           in {
             name = toPkgId memberManifest.package;

--- a/lib/support.nix
+++ b/lib/support.nix
@@ -201,7 +201,7 @@ rec {
           rootFeatures = if features != null then features
             else if pkgSet.${rootId}.features ? default then [ "default" ]
             else [];
-          showFeatures = x: builtins.traceVerbose "Features: ${toJSON x}" x;
+          showFeatures = x: builtins.trace "Features: ${toJSON x}" x;
           resolvedFeatures = showFeatures (resolveFeatures {
             inherit rootId pkgSet rootFeatures;
           });

--- a/lib/support.nix
+++ b/lib/support.nix
@@ -111,8 +111,9 @@ rec {
         listToAttrs
         (map (relativePath:
           let
-            memberRoot = self.nix-filter.lib { root = src + ("/" + relativePath); };
-            memberManifest = fromTOML (readFile (memberRoot + "/Cargo.toml")) // lockVersionSet;
+            memberSrc = src + ("/" + relativePath);
+            memberRoot = self.nix-filter.lib { root = memberSrc; };
+            memberManifest = fromTOML (readFile (memberSrc + "/Cargo.toml")) // lockVersionSet;
           in {
             name = toPkgId memberManifest.package;
             value = mkPkgInfoFromCargoToml memberManifest memberRoot;

--- a/lib/support.nix
+++ b/lib/support.nix
@@ -182,7 +182,7 @@ rec {
           (filter
             ({ kind, name, optional, targetEnabled, resolved, ... }@dep:
               targetEnabled && kind == selectKind
-              && (optional -> elem name features)
+              && (if features ? name then features.${name}.enabled else false)
               && (if resolved == null then throw "Unresolved dependency: ${toJSON dep}" else true)
               && (onlyLinks -> pkgSet.${resolved}.links != null))
             deps);
@@ -212,7 +212,7 @@ rec {
             depFilter = dep: dep.targetEnabled && dep.kind == "normal";
           };
 
-          pkgsBuild = mapAttrs (id: features: let info = pkgSet.${id}; in
+          pkgsBuild = mapAttrs (id: { features, ...}: let info = pkgSet.${id}; in
             if features != null then
               buildRustCrate' info {
                 inherit (info) version src procMacro;
@@ -228,7 +228,7 @@ rec {
               null
           ) resolvedBuildFeatures;
 
-          pkgs = mapAttrs (id: features: let info = pkgSet.${id}; in
+          pkgs = mapAttrs (id: { features, ...}: let info = pkgSet.${id}; in
             if features != null then
               buildRustCrate' info {
                 inherit (info) version src links procMacro;

--- a/lib/support.nix
+++ b/lib/support.nix
@@ -111,8 +111,8 @@ rec {
         listToAttrs
         (map (relativePath:
           let
-            memberSrc = src + ("/" + relativePath);
-            memberRoot = self.nix-filter.lib { root = memberSrc; };
+            memberSrc =  src + ("/" + relativePath);
+            memberRoot = self.nix-filter.lib { root = builtins.trace memberSrc memberSrc; };
             memberManifest = fromTOML (readFile (memberSrc + "/Cargo.toml")) // lockVersionSet;
           in {
             name = toPkgId memberManifest.package;

--- a/lib/support.nix
+++ b/lib/support.nix
@@ -201,10 +201,9 @@ rec {
           rootFeatures = if features != null then features
             else if pkgSet.${rootId}.features ? default then [ "default" ]
             else [];
-          showFeatures = x: builtins.trace "Features: ${toJSON x}" x;
-          resolvedFeatures = showFeatures (resolveFeatures {
+          resolvedFeatures = resolveFeatures {
             inherit rootId pkgSet rootFeatures;
-          });
+          };
 
           buildDependencies = (resolvedFeatures.normal // resolvedFeatures.build);
           normalDependencies = resolvedFeatures.normal;

--- a/lib/support.nix
+++ b/lib/support.nix
@@ -118,7 +118,7 @@ rec {
               in {
                 name = toPkgId memberManifest.package;
                 value = mkPkgInfoFromCargoToml memberManifest memberRoot main-workspace;
-              }) (filter (relativePath: builtins.pathExists ("${src}/${relativePath}/Cargo.toml")) (workspace_members ++ root_package)));
+              }) (filter (relativePath: builtins.pathExists (src + ("/" + (relativePath + "/Cargo.toml")))) (workspace_members ++ root_package)));
 
     in mkRustPackageSet {
       gitSrcInfos = mapAttrs (url: src:

--- a/lib/support.nix
+++ b/lib/support.nix
@@ -112,7 +112,7 @@ rec {
         (map (relativePath:
           let
             memberSrc =  src + ("/" + relativePath);
-            memberRoot = if relativePath == "" then memberSrc else self.nix-filter.lib { root = builtins.trace memberSrc memberSrc; };
+            memberRoot = if relativePath == "" then memberSrc else self.nix-filter.lib { root = memberSrc; };
             memberManifest = fromTOML (readFile (memberSrc + "/Cargo.toml")) // lockVersionSet;
           in {
             name = toPkgId memberManifest.package;

--- a/lib/support.nix
+++ b/lib/support.nix
@@ -294,7 +294,7 @@ rec {
       serde = (head semver.dependencies).drv;
     in assertEq
       [ semver.features serde.features ]
-      [ [ "default" "std" "serde" ] [ /* Don't trigger default features */ ] ];
+      [ ["serde" "std" "default"] [ /* Don't trigger default features */ ] ];
 
     dependency-overrided = let
       ret = build ../tests/features {

--- a/lib/support.nix
+++ b/lib/support.nix
@@ -181,9 +181,8 @@ rec {
           (dep: { rename = dep.rename or null; drv = pkgs.${dep.resolved}; })
           (filter
             ({ kind, name, optional, targetEnabled, resolved, ... }@dep:
-              targetEnabled && kind == selectKind
-              && (if features ? name then features.${name}.enabled else false)
-              && (if resolved == null then throw "Unresolved dependency: ${toJSON dep}" else true)
+              targetEnabled && kind == selectKind && resolved != null
+              && ((features ? ${resolved}) -> features.${resolved}.enabled)
               && (onlyLinks -> pkgSet.${resolved}.links != null))
             deps);
 
@@ -226,7 +225,7 @@ rec {
               }
             else
               null
-          ) resolvedBuildFeatures;
+          ) (builtins.trace "Build features: ${toJSON resolvedBuildFeatures}" resolvedBuildFeatures);
 
           pkgs = mapAttrs (id: { features, ...}: let info = pkgSet.${id}; in
             if features != null then
@@ -241,7 +240,7 @@ rec {
               }
             else
               null
-          ) resolvedNormalFeatures;
+          ) (builtins.trace "Normal features: ${toJSON resolvedNormalFeatures}" resolvedNormalFeatures);
         in
           pkgs.${rootId}
       ) {

--- a/lib/support.nix
+++ b/lib/support.nix
@@ -111,7 +111,7 @@ rec {
             name = toPkgId memberManifest.package;
             value = mkPkgInfoFromCargoToml memberManifest memberRoot;
           }
-          ) (if manifest ? workspace then members else [ "" ]));
+          ) ((if manifest ? workspace then members else []) ++ (if manifest ? package then [ "" ] else [])));
 
     in mkRustPackageSet {
       gitSrcInfos = mapAttrs (url: src:

--- a/lib/support.nix
+++ b/lib/support.nix
@@ -274,7 +274,7 @@ rec {
   in
   {
     features = let ret = build ../tests/features {}; in
-      assertEq ret.features [ "a" "default" "semver" ]; # FIXME
+      assertEq (lib.naturalSort ret.features) [ "a" "default" "semver" ];
 
     dependency-features = let
       ret = build ../tests/features { };
@@ -282,7 +282,7 @@ rec {
       serde = (head semver.dependencies).drv;
     in assertEq
       [ semver.features serde.features ]
-      [ [ "default" "serde" "std" ] [ /* Don't trigger default features */ ] ];
+      [ [ "default" "std" "serde" ] [ /* Don't trigger default features */ ] ];
 
     dependency-overrided = let
       ret = build ../tests/features {

--- a/lib/support.nix
+++ b/lib/support.nix
@@ -108,16 +108,16 @@ rec {
           workspace_members = (if manifest ? workspace then members else []);
           root_package = (if manifest ? package then [ "" ] else []);
         in
-        listToAttrs
-        (map (relativePath:
-          let
-            memberSrc =  src + ("/" + relativePath);
-            memberRoot = if relativePath == "" then memberSrc else self.nix-filter.lib { root = memberSrc; };
-            memberManifest = fromTOML (readFile (memberSrc + "/Cargo.toml")) // lockVersionSet;
-          in {
-            name = toPkgId memberManifest.package;
-            value = mkPkgInfoFromCargoToml memberManifest memberRoot;
-          }) (workspace_members ++ root_package));
+          listToAttrs
+            (map (relativePath:
+              let
+                memberSrc =  src + ("/" + relativePath);
+                memberRoot = if relativePath == "" then memberSrc else self.nix-filter.lib { root = memberSrc; };
+                memberManifest = fromTOML (readFile (memberSrc + "/Cargo.toml")) // lockVersionSet;
+              in {
+                name = toPkgId memberManifest.package;
+                value = mkPkgInfoFromCargoToml memberManifest memberRoot;
+              }) (filter (relativePath: builtins.pathExists ("${src}/${relativePath}/Cargo.toml"))(workspace_members ++ root_package)));
 
     in mkRustPackageSet {
       gitSrcInfos = mapAttrs (url: src:

--- a/lib/support.nix
+++ b/lib/support.nix
@@ -201,15 +201,10 @@ rec {
           rootFeatures = if features != null then features
             else if pkgSet.${rootId}.features ? default then [ "default" ]
             else [];
-
-          resolvedBuildFeatures = resolveFeatures {
+          print = x: builtins.trace (toJSON x) x;
+          resolvedFeatures = print (resolveFeatures {
             inherit pkgSet rootId rootFeatures;
-            depFilter = dep: dep.targetEnabled && dep.kind == "normal" || dep.kind == "build";
-          };
-          resolvedNormalFeatures = resolveFeatures {
-            inherit pkgSet rootId rootFeatures;
-            depFilter = dep: dep.targetEnabled && dep.kind == "normal";
-          };
+          });
 
           pkgsBuild = mapAttrs (id: { features, ...}: let info = pkgSet.${id}; in
             if features != null then
@@ -225,7 +220,7 @@ rec {
               }
             else
               null
-          ) (builtins.trace "Build features: ${toJSON resolvedBuildFeatures}" resolvedBuildFeatures);
+          ) (resolvedFeatures.normal // resolvedFeatures.build);
 
           pkgs = mapAttrs (id: { features, ...}: let info = pkgSet.${id}; in
             if features != null then
@@ -240,7 +235,7 @@ rec {
               }
             else
               null
-          ) (builtins.trace "Normal features: ${toJSON resolvedNormalFeatures}" resolvedNormalFeatures);
+          ) resolvedFeatures.normal;
         in
           pkgs.${rootId}
       ) {

--- a/lib/support.nix
+++ b/lib/support.nix
@@ -296,7 +296,7 @@ rec {
       serde = (head semver.dependencies).drv;
     in assertEq
       [ semver.features serde.features ]
-      [ ["serde" "std" "default"] [ /* Don't trigger default features */ ] ];
+      [ ["default" "serde" "std"] [ /* Don't trigger default features */ ] ];
 
     dependency-overrided = let
       ret = build ../tests/features {

--- a/noc/templates/init-flake.nix
+++ b/noc/templates/init-flake.nix
@@ -9,6 +9,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
+    nix-filter.url = "github:numtide/nix-filter";
     nocargo = {
       url = "github:oxalica/nocargo";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -66,7 +66,7 @@ let
       nativeBuildInputs = [ noc pkgs.nix ];
       checkFlags =
         mapAttrsToList (from: to: "--override-input ${from} ${to}") {
-          inherit (inputs) nixpkgs flake-utils;
+          inherit (inputs) nixpkgs flake-utils nix-filter;
           nocargo = self;
           "nocargo/registry-crates-io" = inputs.registry-crates-io;
           registry-1 = inputs.registry-crates-io;


### PR DESCRIPTION
This MR adds support for weak dependency features, and the new optional feature syntax, as well as workspace inheritance of cargo toml properties. 

## Feature resolver
I've completely rewritten the `resolver.rs` file, in order to support the new features. I stopped using overlays and instead went with attribute sets together with a merging function. I thought I could do it entirely stateless (without remembering which features were activated before the one we're activating), but I think it is impossible, exactly because of weak dependency features. Instead, the code looks more like a continuation passing style, where I pass the state of the packages into the next function (the `seen` argument, present in almost all functions).

Still, the code does look very similar to cargo's new feature resolver code, and it gives pretty good results: I've been able to compile `cargo` and `alacritty` with it and it is reasonably fast. Both of them are quite feature/dependency heavy so I think they give a fairly good stress test. 

There still are some rough edges that I'm not sure I implemented correctly, mainly dev features not ending up mangling with normal features (see `resolver.nix#L195`), but the way I fixed it seems to give correct results. Also, `nix flake check` is failing, but with an error related to `gen-workspaces` git sources (it seems like there are some old urls? I haven't given a proper look), and I don't believe my changes have caused it.

## Workspace Inheritance

This feature was mainly needed in order to compile `cargo`, because it is used fairly often there. The main changes that come from this is that `pkgSet` now must hold the `edition` when we call `mkPkgInfoFromCargoToml`, which also needs workspace variable to inherit from. I haven't added all the features that should be added here, just the ones necessary to compile cargo.

