### PR TITLE
fix cargo pkg version parsing

### DIFF
--- a/build-rust-crate/builder-common.sh
+++ b/build-rust-crate/builder-common.sh
@@ -119,9 +119,9 @@ setCargoCommonBuildEnv() {
         CARGO_PKG_HOMEPAGE CARGO_PKG_LICENSE CARGO_PKG_LICENSE_FILE
 
     if [[ "$version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-([A-Za-z0-9.-]+))?(\+.*)?$ ]]; then
-        export CARGO_PKG_VERSION_MAJOR="${BASH_REMATCH[0]}"
-        export CARGO_PKG_VERSION_MINOR="${BASH_REMATCH[1]}"
-        export CARGO_PKG_VERSION_PATCH="${BASH_REMATCH[2]}"
+        export CARGO_PKG_VERSION_MAJOR="${BASH_REMATCH[1]}"
+        export CARGO_PKG_VERSION_MINOR="${BASH_REMATCH[2]}"
+        export CARGO_PKG_VERSION_PATCH="${BASH_REMATCH[3]}"
         export CARGO_PKG_VERSION_PRE="${BASH_REMATCH[4]}"
     else
         echo "Invalid version: $version"


### PR DESCRIPTION
The `setCargoCommonBuildEnv` function in `builder-common.sh` doesn't properly use `BASH_REMATCH` to parse the version number. The 0 index of `BASH_REMATCH` is the whole string so the `CARGO_PKG_VERSION_MAJOR` was failing with an `InvalidDigit` Error. I noticed this when trying to package the `ffmpeg-sys-next` crate using nocargo.