### PR TITLE
Feature resolver imperative

### DIFF
--- a/lib/resolve.nix
+++ b/lib/resolve.nix
@@ -24,7 +24,7 @@ in rec {
   # }
   #
   # Currently (rust 1.63.0), there are 3 versions of the lock file.
-  # We supports V1, V2 and V3.
+  # We support V1, V2 and V3.
   # See:
   # https://github.com/rust-lang/cargo/blob/rust-1.63.0/src/cargo/core/resolver/resolve.rs#L56
   # https://github.com/rust-lang/cargo/blob/rust-1.63.0/src/cargo/core/resolver/encode.rs


### PR DESCRIPTION
This is mostly a backport of only the feature resolver part of my own branch o-santi/nocargo@213019f· It was initially proposed in #17, but it also included workspace inheritance and other additional tweaks, which I've separated and kept off for another later PRs. It also includes some additional documentation, bug fixes and performance improvements that the original PR did not contain.

What follows is the original motivation for it, as is, from its proposal in this branch:

# Original

Since Rust 1.60, cargo shipped new features for features in packages, namely:

- weak dependency features: if package `foo` has an optional dependency `bar` (disabled by default), and `bar` has a feature named `baz`, the feature `bar/baz` on `foo` enables both the `bar` dependency and the feature `baz` on `bar`. This was pre-1.60 and `nocargo` already has support for this. However, this behavior is not always wanted, we may need to enable `baz` only if another feature enabled `bar` (without enabling the dependency). This is called by cargo as weak dependency feature, and the syntax for it is `bar?/baz`, and `nocargo` did not have support for it (which is why it had a line commenting "v2 is too new to understand").
- optional dependencies: in pre-1.60 rust, optional packages defined an implicit feature that enabled it, with the same name, ie. if package `foo` has an optional dependency `bar`, then it created an implicit feature named `bar` that enabled the dependency. `nocargo` had support for this. Though, after 1.60 it defined a new syntax, namely `dep:bar`, that `nocargo` did not support.

Now I will try to explain the logic behind `nocargo`, why it was hard to implement it before, and what I did to change it. It is easier to understand if we try to understand `cargo` first:

1. read `Cargo.toml`, figure out which dependencies are needed and to which versions, and save that in `Cargo.lock`. Since there are `2^n` possible combinations of `n` dependencies (plus all features), it can't possibly try all of them one at a time. What it does is assume that all features are enabled in the main package and resolve from there. That means that there should be a surplus of dependencies in `Cargo.lock` for any given build: it tries to find all of them at once, so in order to resolve further we must parse `Cargo.lock` and try to figure out which of the dependencies are enabled.
2. After that, it will parse `Cargo.lock` and try to figure out the dependencies. Given that features can enable dependencies, we need to also resolve which features will be enabled for which dependencies, and gather all those packages into a huge set. We also need to remember that in rust there's a notion of build dependencies vs normal dependencies (vs dev dependencies, usually for tests), as there is in nix (and in fact these concepts line up really well) and so we must also figure that out. There's a third degree to this: the fact that some dependencies should only be enabled in certain targets (`cfg(windows)` or `cfg(target_os = "macos")`), so we need to take that into account as well.
3. With all those resolved, it must walk the dependencies in a topological sort order and fetch and build one at a time, with their own set of dependencies and features. This should be the easiest step, as should be a list walk calling `rustc` with different arguments.

For a fact, `nocargo` does not implement **1.** (yet!), as it is probably the hardest: version resolving in a Cargo.toml is basically a SAT solver implementation and that is not easy to implement correctly (specially when trying to be fast). oxalica noted this in multiple places, and it is why we need a `Cargo.lock` already generated in the root of the project before trying to compile. There's even a bigger problem because the `Cargo.lock` needs to have versions that we can see from the cargo package registry index, which isn't always the case. @rigille1 tried his hand at this, adding a derivation for the Cargo.lock that overrides the `cargo` registry and generates the correct version, but this is at most a band-aid at this problem (IFD!) and we should implement it correctly in the future. The cargo implementation is open source and it offers it's internals as a lib that we could simply use to generate the Cargo.lock, but I think it might be fun to actually try and solve the versions (though hard!).

Now, the problem that I'm tackling is **2.**. The `nocargo` workflow goes kind of like this:

1. the user calls `mkRustPackageOrWorkspace`
2. which then reads the `Cargo.lock` file, and calls `mkRustPackageSet` (the one that does the work).
3. in `mkRustPackageSet`, it generates a `nixpkgs` like variable called `pkgSet`, using the information from the `lock` and from what it can gather from the registries. It's a set holding `{ pkg_name = pkg_info; }` for each of the pkgs resolved from `lock`, and in `pkg_info` set we find both the defined `features` list and the `dependencies`.
4. then, it passes it to `mkPkg`, which uses all of that information to call `resolveFeatures` (our main function of interest), and then pass it to `buildRustCrate` which generate the actual derivation (`rustc` calls).

The structure of `resolveFeatures` return value is a set of `{ pkg_resolved_name = feature_list; }` where `pkg_resolved_name` is a string of `{pkg.name} {pkg.version} {pkg.registry_url}` which is enough to identify each dependency (as we may have multiple versions of the same package in `pkgSet`). And here we see our first problem: there's no way to infer which dependencies are enabled from the return of this function call, as we may need to enable a feature without enabling a dependency (recall the `bar?/baz` example). The only logical conclusion is that the packages that appear in this set are exactly those that are enabled for the whole build (no more, no less) and if a package's feature is enabled but it itself is disabled then those changes eventually must be discarded from the resulting set. This is the main problem: it wasn't being done like that before, and that was the purpose of the `selectDeps` function: filter from the features that were enabled only those that should be, but as we concluded, there isn't enough information for this, and as such we must change it.

Oxalica's approach to `resolveFeatures` was to first try to figure out all the features that should be enabled for all packages (even those that are optional), but the main function (`enableFeatures`) could only enable features on the `pkgId` that it was called on, so it possibly couldn't figure out which ones were enabled. Besides, it was also using overlays, which are the correct approach for this problem, but I found them really confusing (as they are extremely recursive and simple mistakes can make them enter infinite loops).

My approach was then the following: change the main representation of the graph from `{ pkg_resolved_name = feature_list; }` to `{ build_kind = { pkg_resolved_name = { features = feature_list; enabled = bool }; }; }` to know which packages are enabled and which ones are not, to which build kind (`normal`, `dev`, `build`, but I don't hard code those and instead use variables). Then, we start by enabling the root package, recursively enabling all non-optional dependencies, and then enabling all the `rootFeatures` (which should enable the required optional packages). The whole idea is that enabling a feature may occur a change in another package in another build kind (ie. a normal feature might enable a build or dev dependency), and as such the `enableFeature` function must be able to do that.

To achieve this, I threw away the overlays (honestly because I found it too hard) and instead went with a merging sets approach: `enableFeature` and `enablePackageWithFeatures` both return the same type as the whole graph, and after each step I merge the changes returned, concatenating the features list and or'ing the `enabled` field (if a dependency is enabled only once by some package then it is enough to enable it globally). Initially I tried carrying around a flag in `enableFeature` that meant if that feature should enable the whole package or not, but I figured that shouldn't be needed at all: the only place where we need to enable the packages is at `enablePackageWithFeatures`, and at all other places we can just set the `enabled` to false. I believe there should be some smarter scheme where I completely get rid of the `enabled` field but I honestly haven't seen it yet. This is by no means the easiest nor the most performant approach, but it is the one that I found the easiest to understand.

There's one last caveat, which is that we might have cyclic features (`a` enables `b` which enables `a` again), which probably is what made oxalica go with the overlay approach in the first place, but that just means that we need to carry around a `seen` package set to avoid going again into the same features (and dependencies). It should also function as an optimization (though I should do it globally), as most packages end up enabling the same dependencies (looking at you `once_cell` and `proc_macros2`), and this avoids doing unnecessary work enabling them multiple times.